### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/apps/ed/README.md
+++ b/apps/ed/README.md
@@ -64,6 +64,6 @@ lines before current line and ending 2 lines after it`.
 
 `+` alone means `+1`, `-` means `-1`.
 
-`.` means current line. It can usually be ommitted. `p` is the same as `.p`.
+`.` means current line. It can usually be omitted. `p` is the same as `.p`.
 
 `$` means the last line of the buffer.

--- a/apps/zasm/README.md
+++ b/apps/zasm/README.md
@@ -46,7 +46,7 @@ For example, a label placed at the beginning of the file is associated with
 offset 0. If placed right after a first instruction that is 2 bytes wide, then
 the label is going to be bound to 2.
 
-Those labels can then be referenced wherever a constant is expeced. They can
+Those labels can then be referenced wherever a constant is expected. They can
 also be referenced where a relative reference is expected (`jr` and `djnz`).
 
 Labels can be forward-referenced, that is, you can reference a label that is
@@ -128,7 +128,7 @@ allowed. An included file cannot have an `.inc` directive.
 **.fill**: Outputs the number of null bytes specified by its argument, an
            expression. Often used with `$` to fill our binary up to a certain
            offset. For example, if we want to place an instruction exactly at
-           byte 0x38, we would preceed it with `.fill 0x38-$`.
+           byte 0x38, we would precede it with `.fill 0x38-$`.
 
 **.org**: Sets the Program Counter to the value of the argument, an expression.
           For example, a label being defined right after a `.org 0x400`, would

--- a/apps/zasm/instr.asm
+++ b/apps/zasm/instr.asm
@@ -895,7 +895,7 @@ parseInstruction:
 
 
 ; In instruction metadata below, argument types arge indicated with a single
-; char mnemonic that is called "argspec". This is the table of correspondance.
+; char mnemonic that is called "argspec". This is the table of correspondence.
 ; Single letters are represented by themselves, so we don't need as much
 ; metadata.
 ; Special meaning:

--- a/apps/zasm/io.asm
+++ b/apps/zasm/io.asm
@@ -1,6 +1,6 @@
 ; I/Os in zasm
 ;
-; As a general rule, I/O in zasm is pretty straightfoward. We receive, as a
+; As a general rule, I/O in zasm is pretty straightforward. We receive, as a
 ; parameter, two blockdevs: One that we can read and seek and one that we can
 ; write to (we never seek into it).
 ;

--- a/kernel/fs.asm
+++ b/kernel/fs.asm
@@ -322,7 +322,7 @@ fsIsValid:
 	pop	hl
 	ret
 
-; Returns wheter current block is deleted in Z flag.
+; Returns whether current block is deleted in Z flag.
 fsIsDeleted:
 	ld	a, (FS_META+FS_META_FNAME_OFFSET)
 	cp	0	; Z flag is our answer

--- a/kernel/shell.asm
+++ b/kernel/shell.asm
@@ -47,7 +47,7 @@
 ; Pointer to a hook to call when a cmd name isn't found
 .equ	SHELL_CMDHOOK	SHELL_CMD_ARGS+PARSE_ARG_MAXCOUNT
 
-; Pointer to a routine to call at each shell loop interation
+; Pointer to a routine to call at each shell loop iteration
 .equ	SHELL_LOOPHOOK	SHELL_CMDHOOK+2
 .equ	SHELL_RAMEND	SHELL_LOOPHOOK+2
 

--- a/recipes/sms/kbd/README.md
+++ b/recipes/sms/kbd/README.md
@@ -34,7 +34,7 @@ SR latch.
 In this recipe, I do have a SR latch on hand, so I'll use it. `TH` triggering
 will also trigger that latch, indicating to the MCU that it can load the next
 character in the '164. When it's done, we signal the SMS that the next char is
-ready by reseting the latch. That means that we have to hook the latch's output
+ready by resetting the latch. That means that we have to hook the latch's output
 to `TR`.
 
 Nibble selection on `TH` doesn't involve the AVR at all. All 8 bits are
@@ -79,7 +79,7 @@ machine...
 
 ![Schematic](ps2-to-sms.png)
 
-The PS/2-to-AVR part is indentical to the rc2014/ps2 recipe. Refer to this
+The PS/2-to-AVR part is identical to the rc2014/ps2 recipe. Refer to this
 recipe.
 
 We control the '164 from the AVR in a similar way to what we did in rc2014/ps2,


### PR DESCRIPTION
Found via `codespell -q 3 -S ./tools -L splitted`