### PR TITLE
Fix for tools/zasm.sh being dependent on readlink -f (an issue on macOS, preventing builds)

### DIFF
--- a/tools/zasm.sh
+++ b/tools/zasm.sh
@@ -1,7 +1,11 @@
-#!/bin/sh
+#!/bin/bash
+
+# readlink -f doesn't work with macOS's implementation (BSD in general?)
+# so, if we can't get readlink -f to work, try python with a realpath implementation
+ABS_PATH=$(readlink -f "$0" || python -c "import sys, os; print(os.path.realpath('$0'))")
 
 # wrapper around ./emul/zasm/zasm that prepares includes CFS prior to call
-DIR=$(dirname $(readlink -f "$0"))
+DIR=$(dirname "${ABS_PATH}")
 ZASMBIN="${DIR}/emul/zasm/zasm"
 CFSPACK="${DIR}/cfspack/cfspack"
 INCCFS=$(mktemp)

--- a/tools/zasm.sh
+++ b/tools/zasm.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# readlink -f doesn't work with macOS's implementation (BSD in general?)
+# readlink -f doesn't work with macOS's implementation
 # so, if we can't get readlink -f to work, try python with a realpath implementation
 ABS_PATH=$(readlink -f "$0" || python -c "import sys, os; print(os.path.realpath('$0'))")
 


### PR DESCRIPTION
A small issue I ran into `zasm.sh` was dependent on `readlink -f`, an issue on macOS's non-GNU readlink (likely an issue on other BSD's, also)

One of the main ways of fixing it seems to just be to use Python's readlink

https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac

I was also running into dumb issues trying to install GNU readlink. This also works on Python 2 and 3 :)