### PR TITLE
Make blkpack close files when it's done reading them

### DIFF
--- a/tools/blkpack.c
+++ b/tools/blkpack.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <errno.h>
 #include <string.h>
 #include <sys/stat.h>
 
@@ -41,6 +42,10 @@ int main(int argc, char *argv[])
         strcat(fullpath, "/");
         strcat(fullpath, ep->d_name);
         FILE *fp = fopen(fullpath, "r");
+        if (fp == NULL) {
+            fprintf(stderr, "Could not open %s: %s\n", ep->d_name, strerror(errno));
+            continue;
+        }
         char *line = NULL;
         size_t n = 0;
         for (int i=0; i<16; i++) {

--- a/tools/blkpack.c
+++ b/tools/blkpack.c
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, "blk %s has more than 16 lines\n", ep->d_name);
         }
         free(line);
+        fclose(fp);
     }
     fwrite(buf, 1024, blkcnt, stdout);
     free(buf);


### PR DESCRIPTION
blkpack kept having a segfault on MacOS. I built it with debug symbols turned on and ran it in lldb. The culprit line was `ssize_t cnt = getline(&line, &n, fp);` because `fp` was `NULL`. I threw in a null check to report why a line could not be opened, and it's because the OS says to many files open. To remedy that, I closed the files after they've been read.